### PR TITLE
Cargo.toml: Exclude .clippy.toml and .githooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://stratis-storage.github.io"
 repository = "https://github.com/stratis-storage/libblkid-rs"
 categories = ["os::linux-apis", "api-bindings"]
 keywords = ["storage"]
-exclude = [".github/*", ".gitignore", "Makefile"]
+exclude = [".clippy.toml", ".githooks/*", ".github/*", ".gitignore", "Makefile"]
 
 [dependencies.libblkid-rs-sys]
 version = "0.1.0"


### PR DESCRIPTION
Related: stratis-storage/project#485