### PR TITLE
Restrict bindgen features to remove clap dependency

### DIFF
--- a/libblkid-rs-sys/Cargo.toml
+++ b/libblkid-rs-sys/Cargo.toml
@@ -12,5 +12,9 @@ categories = ["os::linux-apis", "external-ffi-bindings"]
 keywords = ["storage"]
 
 [build-dependencies]
-bindgen = "0.59.0"
 cc = "1.0.45"
+
+[build-dependencies.bindgen]
+default_features = false
+features = ["runtime"]
+version = "0.59.0"


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/333