### PR TITLE
build.rs: Use pkg-config to find header search paths for bindgen.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ uuid = "1.0.0"
 [features]
 default = []
 deprecated = []
+static = ["libblkid-rs-sys/static"]
 
 [lints.rust]
 warnings = { level = "deny" }

--- a/libblkid-rs-sys/Cargo.toml
+++ b/libblkid-rs-sys/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["storage"]
 
 [build-dependencies]
 cc = "1.0.45"
+pkg-config = "0.3.31"
 
 [build-dependencies.bindgen]
 default-features = false
@@ -30,3 +31,6 @@ nonstandard_style = { level = "deny", priority = 4 }
 [lints.clippy]
 all = { level = "deny" }
 cargo = { level = "deny" , priority = 1}
+
+[features]
+static = []


### PR DESCRIPTION
This optionally enables using pkg-config to find header search paths and linker paths.  The pkg-config crate prints "cargo:rustc-link-lib=blkid" along with the appropriate library search paths. 

Additionally this adds an option static feature for statically linking libblkid.  