### PR TITLE
Increase libblkid-rs-sys dependency lower bound to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["storage"]
 exclude = [".clippy.toml", ".githooks/*", ".github/*", ".gitignore", "Makefile"]
 
 [dependencies.libblkid-rs-sys]
-version = "0.3.0"
+version = "0.3.1"
 path = "./libblkid-rs-sys"
 
 [dependencies]


### PR DESCRIPTION
Related https://github.com/stratis-storage/libblkid-rs/pull/171