### PR TITLE
Fix macOS build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,18 @@
 fn main() {
-    let mut pkg_config = pkg_config::Config::new();
-    let pkg_config = pkg_config.atleast_version("2.33.2");
-    let libblkid = pkg_config
-        .cargo_metadata(false)
-        .probe("blkid")
-        .expect("Failed to find libblkid?");
-    for arg in libblkid.libs.iter() {
-        println!("cargo:rustc-link-arg=-l{arg}");
+    let host = std::env::var("HOST").unwrap();
+    let target = std::env::var("TARGET").unwrap();
+
+    if host != target {
+        // cross-compilation
+
+        let mut pkg_config = pkg_config::Config::new();
+        let pkg_config = pkg_config.atleast_version("2.33.2");
+        let libblkid = pkg_config
+            .cargo_metadata(false)
+            .probe("blkid")
+            .expect("Failed to find libblkid?");
+        for arg in libblkid.libs.iter() {
+            println!("cargo:rustc-link-arg=-l{arg}");
+        }
     }
 }

--- a/libblkid-rs-sys/build.rs
+++ b/libblkid-rs-sys/build.rs
@@ -9,10 +9,16 @@ fn main() {
     {
         pkg_config.statik(true);
     }
-    let libblkid = pkg_config
-        .cargo_metadata(false)
-        .probe("blkid")
-        .expect("Failed to find libblkid?");
+
+    let host = env::var("HOST").unwrap();
+    let target = env::var("TARGET").unwrap();
+
+    if host != target {
+        // cross-compilation
+        pkg_config.cargo_metadata(false);
+    }
+
+    let libblkid = pkg_config.probe("blkid").expect("Failed to find libblkid?");
 
     let bindings = Builder::default()
         .clang_args(


### PR DESCRIPTION
I'm not sure what exactly cargo metadata does but https://github.com/stratis-storage/libblkid-rs/commit/609aab40e11fbfcf35088b0f8b18e902c4dcd093 broke my build with linker errors:

```
  Undefined symbols for architecture arm64:
    "_blkid_do_safeprobe", referenced from:
        libblkid_rs::probe::BlkidProbe::do_safeprobe::h99485a5d24512e80 in liblibblkid_rs-0b248e8a09844861.rlib[6](libblkid_rs-0b248e8a09844861.libblkid_rs.7375e6b3ccd5aca0-cgu.03.rcgu.o)
    "_blkid_free_probe", referenced from:
        _$LT$libblkid_rs..probe..BlkidProbe$u20$as$u20$core..ops..drop..Drop$GT$::drop::h629a0bdf7f70e0bf in liblibblkid_rs-0b248e8a09844861.rlib[6](libblkid_rs-0b248e8a09844861.libblkid_rs.7375e6b3ccd5aca0-cgu.03.rcgu.o)
    "_blkid_new_probe_from_filename", referenced from:
        libblkid_rs::probe::BlkidProbe::new_from_filename::hdc4581aa633e0b3c in liblibblkid_rs-0b248e8a09844861.rlib[6](libblkid_rs-0b248e8a09844861.libblkid_rs.7375e6b3ccd5aca0-cgu.03.rcgu.o)
    "_blkid_probe_enable_superblocks", referenced from:
        libblkid_rs::probe::BlkidProbe::enable_superblocks::h0882b0d9c14a8263 in liblibblkid_rs-0b248e8a09844861.rlib[6](libblkid_rs-0b248e8a09844861.libblkid_rs.7375e6b3ccd5aca0-cgu.03.rcgu.o)
    "_blkid_probe_lookup_value", referenced from:
        libblkid_rs::probe::BlkidProbe::lookup_value::h2f0c5f09b46a1fb6 in liblibblkid_rs-0b248e8a09844861.rlib[6](libblkid_rs-0b248e8a09844861.libblkid_rs.7375e6b3ccd5aca0-cgu.03.rcgu.o)
    "_blkid_probe_set_superblocks_flags", referenced from:
        libblkid_rs::probe::BlkidProbe::set_superblock_flags::hfd4187186f358001 in liblibblkid_rs-0b248e8a09844861.rlib[6](libblkid_rs-0b248e8a09844861.libblkid_rs.7375e6b3ccd5aca0-cgu.03.rcgu.o)
  ld: symbol(s) not found for architecture arm64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

So I decided to fix it by partially reverting the offending change. Is it OK to merge it like this?