### PR TITLE
Add namespaced variables for cross-compilation in libblkid-rs

### DIFF
--- a/libblkid-rs-sys/build.rs
+++ b/libblkid-rs-sys/build.rs
@@ -3,6 +3,11 @@ use bindgen::Builder;
 use std::{env, path::PathBuf};
 
 fn main() {
+    let _ = env::var("LIBBLKID_RS_PKG_CONFIG_PATH").map(|v| env::set_var("PKG_CONFIG_PATH", v));
+    let _ = env::var("LIBBLKID_RS_PKG_CONFIG_LIBDIR").map(|v| env::set_var("PKG_CONFIG_LIBDIR", v));
+    let _ = env::var("LIBBLKID_RS_PKG_CONFIG_SYSROOT_DIR")
+        .map(|v| env::set_var("PKG_CONFIG_SYSROOT_DIR", v));
+
     let mut pkg_config = pkg_config::Config::new();
     let pkg_config = pkg_config.atleast_version("2.33.2");
     #[cfg(feature = "static")]


### PR DESCRIPTION
Related to stratis-storage/project#583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Build now honors three LIBBLKID_RS_PKG_CONFIG_* environment variables to influence pkg-config discovery (path, libdir, sysroot) during builds.

- **Bug Fixes**
  - More reliable detection of libblkid in nonstandard prefixes and cross-compilation or custom build environments, reducing build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->