### PR TITLE
github actions: Update recommended Rust to 1.90.0

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
-          toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+          toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - name: Check out ci repo
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,22 +22,22 @@ jobs:
       matrix:
         include:
           - components: rustfmt
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: fmt-ci
           - components: clippy
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: clippy
           - components: cargo
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: build
           - components: cargo
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: test
           - components: cargo
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: docs-ci
           - components: cargo
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: check-typos
           - components: cargo
             toolchain: 1.77.0  # LOWEST SUPPORTED RUST TOOLCHAIN
@@ -67,10 +67,10 @@ jobs:
       matrix:
         include:
           - components: cargo
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: build
           - components: cargo
-            toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+            toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
             task: test
           - components: cargo
             toolchain: 1.77.0  # LOWEST SUPPORTED RUST TOOLCHAIN

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
-          toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+          toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - name: Install dependencies
         run: |
           sudo apt-get -q update
@@ -53,7 +53,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
-          toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+          toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - name: Check out ci repo
         uses: actions/checkout@v5
         with:
@@ -91,10 +91,10 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           verbose: true
-          rust-toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+          rust-toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
           manifest-path: libblkid-rs-sys
       - name: Do semantic version checks
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           verbose: true
-          rust-toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
+          rust-toolchain: 1.90.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to use Rust 1.90.0 (from 1.89.0) across all workflows, including checks, macOS checks, nightly, and related jobs.
  * Retained the lowest-supported toolchain at 1.77.0.
  * No changes to application behavior or public interfaces; this is a maintenance update to keep build and test environments current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->